### PR TITLE
Fetchfiles type option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -48,9 +48,7 @@ module.exports = {
 	 * @param {string[]} requiredFlags An array of the required flags for the command (in any order).
 	 */
 	checkRequiredFlags: function (enteredFlags, requiredFlags) {
-		if (requiredFlags.every((flag) => {
-			return flag in enteredFlags;
-		})) {
+		if (requiredFlags.every((flag) => flag in enteredFlags)) {
 			return true;
 		}
 
@@ -65,7 +63,7 @@ module.exports = {
 	 *
 	 * @param {string} portString
 	 * @returns {number} The number representation of portString on no-error.
-	 *					 Returns the default port number on error.
+	 * Returns the default port number on error.
 	 */
 	checkPortNumber: function (portString) {
 		if (!portString) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -53,7 +53,7 @@ module.exports = {
 	 * Recursively and asynchronously moves through a directory and
 	 * returns the list of files in that directory.
 	 * @param {string} dir The current file directory.
-	 * @param {string} type The type of files to look for.
+	 * @param {string} [type='any'] The type of files to look for.
 	 *
 	 * Options: "any":      returns all files in dir.
 	 *
@@ -62,6 +62,10 @@ module.exports = {
 	 *          "html":     returns only .html and .htm files.
 	 *
 	 *          "assets":   returns all files that "css" and "html" does not return.
+	 * @param {object} [partition] Partition information for the fetch.
+	 * @param {number} partition.split The number of partitions to split into.
+	 * @param {number} partition.partition The partition number to process.
+	 *
 	 * @return {object} The files grouped by `css`, `html`, and `other`.
 	 */
 	_fetchFiles: async function (dir, type = 'any', partition) {
@@ -85,14 +89,20 @@ module.exports = {
 			const partitionEnd = partitionStart + partitionSize;
 			const filePartition = files.slice(partitionStart, partitionEnd);
 
+			const doReturn = {
+				css: type === 'any' || type === 'css',
+				html: type === 'any' || type === 'html',
+				assets: type === 'any' || type === 'assets'
+			};
+
 			filePartition.forEach((file) => {
 				const ext = Path.extname(file);
 
-				if (regex.css.test(ext)) {
+				if (regex.css.test(ext) && doReturn.css) {
 					filesByType.css.push(file);
-				} else if (regex.html.test(ext)) {
+				} else if (regex.html.test(ext) && doReturn.html) {
 					filesByType.html.push(file);
-				} else {
+				} else if (!regex.css.test(ext) && !regex.html.test(ext) && doReturn.assets) {
 					filesByType.other.push(file);
 				}
 			});

--- a/test/runner.js
+++ b/test/runner.js
@@ -72,17 +72,21 @@ describe('_fetchFiles', function () {
 		});
 	});
 	context('type = css', function () {
-		it('should retrieve all files', async function () {
+		it('should retrieve all css files', async function () {
 			const results = await runner._fetchFiles('test/forTesting', 'css');
 			expect(results.css.length).to.equal(2);
+			expect(results.html.length).to.equal(0);
+			expect(results.other.length).to.equal(0);
 			expect(results.css.every((file) => path.extname(file) === '.css')).to.equal(true);
 		});
 	});
 
 	context('type = html', function () {
-		it('should retrieve all files', async function () {
+		it('should retrieve all html files', async function () {
 			const results = await runner._fetchFiles('test/forTesting', 'html');
 			expect(results.html.length).to.equal(2);
+			expect(results.css.length).to.equal(0);
+			expect(results.other.length).to.equal(0);
 			expect(results.html.every((file) => path.extname(file) === '.html')).to.equal(true);
 		});
 	});
@@ -91,6 +95,8 @@ describe('_fetchFiles', function () {
 		it('should retrieve all files', async function () {
 			const results = await runner._fetchFiles('test/forTesting', 'assets');
 			expect(results.other.length).to.equal(2);
+			expect(results.css.length).to.equal(0);
+			expect(results.html.length).to.equal(0);
 			expect(results.other.every((file) => path.extname(file) === '.jpg')).to.equal(true);
 		});
 	});
@@ -101,27 +107,27 @@ describe('_fetchFiles', function () {
 		);
 
 		before(async function () {
-			this.defaultPartition = await runner._fetchFiles('test/forTesting', 'assets');
-			this.partition1 = await runner._fetchFiles('test/forTesting', 'assets', { split: 2, partition: 1 });
-			this.partition2 = await runner._fetchFiles('test/forTesting', 'assets', { split: 2, partition: 2 });
+			this.defaultPartition = await runner._fetchFiles('test/forTesting', 'any');
+			this.partition1 = await runner._fetchFiles('test/forTesting', 'any', { split: 2, partition: 1 });
+			this.partition2 = await runner._fetchFiles('test/forTesting', 'any', { split: 2, partition: 2 });
 		});
 
 		it('prevents invalid `split` or `partition` value', async function () {
-			const partition = await runner._fetchFiles('test/forTesting', 'assets', { split: 0, partition: 0 });
+			const partition = await runner._fetchFiles('test/forTesting', 'any', { split: 0, partition: 0 });
 			const files = getPartitionFiles(partition);
 
 			expect(files.length).to.equal(6);
 		});
 
 		it('prevents undefined `split` or `partition` value', async function () {
-			const partition = await runner._fetchFiles('test/forTesting', 'assets', { split: undefined, partition: undefined });
+			const partition = await runner._fetchFiles('test/forTesting', 'any', { split: undefined, partition: undefined });
 			const files = getPartitionFiles(partition);
 
 			expect(files.length).to.equal(6);
 		});
 
 		it('ensured `partition` is not greater than `split`', async function () {
-			const partition = await runner._fetchFiles('test/forTesting', 'assets', { split: 1, partition: 2 });
+			const partition = await runner._fetchFiles('test/forTesting', 'any', { split: 1, partition: 2 });
 			const files = getPartitionFiles(partition);
 
 			expect(files.length).to.equal(6);


### PR DESCRIPTION
_fetchFiles() will now properly only return the desired type, saving passing potentially large objects around