### PR TITLE
Ignore empty style tags and attributes

### DIFF
--- a/lib/processors/html.js
+++ b/lib/processors/html.js
@@ -89,6 +89,9 @@ function rewriteHTML(html, sitePath, baseurl, extraSrcAttrs) {
 	$('[style]').not('[reseed-ignore]').each(function () {
 		const $el = $(this);
 		const css = $el.attr('style');
+
+    if (css.trim().length === 0) return;
+
 		const updated = rewriteCSS(css, sitePath, baseurl);
 
 		if (updated !== css) {
@@ -99,6 +102,9 @@ function rewriteHTML(html, sitePath, baseurl, extraSrcAttrs) {
 	$('style').not('[reseed-ignore]').each(function () {
 		const $el = $(this);
 		const css = $el.html();
+
+    if (css.trim().length === 0) return;
+
 		const updated = rewriteCSS(css, sitePath, baseurl);
 
 		if (updated !== css) {


### PR DESCRIPTION
Otherwise an exception is thrown on parserlib:

```
TypeError: Cannot read properties of null (reading 'getLine')
```